### PR TITLE
Get code to compile on v0.13.0 of zig

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -348,7 +348,7 @@ fn align_up(v: usize, align_v: usize) usize {
 
 pub const BumpConfig = struct {
     child_allocator: Allocator,
-    budget_log2: u8 = @typeInfo(usize).int.bits - 1, // practically unlimited
+    budget_log2: u8 = @bitSizeOf(usize) - 1, // practically unlimited
     min_alloc_size_log2: u8 = 20, // 1 MB
 };
 


### PR DESCRIPTION
I needed to make this change to get code to compile:
![image](https://github.com/user-attachments/assets/89d02464-9fc5-461c-a1ea-9ede8a208f29)

Not sure what was different between our environments :thinking: 
